### PR TITLE
Adding token support to Staging client

### DIFF
--- a/onboard/client/staging.py
+++ b/onboard/client/staging.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from .helpers import ClientBase
 from .util import json
 
@@ -7,9 +7,10 @@ class StagingClient(ClientBase):
     """Staging area API bindings"""
 
     def __init__(self, api_url: str,
-                 api_key: str, name: str = '') -> None:
-        super().__init__(api_url, api_key=api_key, name=name,
-                         user=None, pw=None, token=None)
+                 api_key: Optional[str] = None,
+                 token: Optional[str] = None,
+                 name: str = '') -> None:
+        super().__init__(api_url, user=None, pw=None, api_key=api_key, token=token, name=name)
 
     @json
     def get_staging_building_details(self) -> List[Dict]:

--- a/onboard/client/util.py
+++ b/onboard/client/util.py
@@ -24,7 +24,7 @@ def json(func: Callable[..., T]) -> Callable[..., T]:
 
             # remove the cached access token if authorization failed
             # it's likely just expired
-            if res.status_code == 401 and args[0].token is not None:
+            if res.status_code == 401 and args and args[0].token is not None:
                 args[0].token = None
                 return wrapper(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setup(name='onboard.client',
-      version='1.9.0',
+      version='1.9.1',
       author='Nathan Merritt',
       author_email='nathan.merritt@onboarddata.io',
       description='Onboard API SDK',


### PR DESCRIPTION
Stopgap for some oauth integration work. Probably want to round out the entire staging client for all forms of auth. And then unsure on versioning model, if we want to just bump the patch version or minor for this.