### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.UPDATER_PAT }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0)** on 2026-06-18T13:53:05Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v6.3.0](https://github.com/actions/setup-python/releases/tag/v6.3.0)** on 2026-06-24T02:48:35Z
